### PR TITLE
Flask Session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /db
 *.log
 .idea
+.venv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "src/bootstrap"]
 	path = src/bootstrap
 	url = https://github.com/twbs/bootstrap.git
-[submodule "src/EncryptedSession"]
-	path = src/EncryptedSession
-	url = https://github.com/SaintFlipper/EncryptedSession.git
 [submodule "src/gnucash"]
 	path = src/gnucash
 	url = https://github.com/Gnucash/gnucash

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ./README.md ./
 COPY --from=builder /wheels /wheels
 
 RUN apk add libpq  mariadb-client
-RUN pip install -v --no-cache /wheels/* .[pgsql,mysql] gunicorn
+RUN pip install -v --no-cache /wheels/* .[pgsql,mysql,redis] gunicorn
 RUN rm -r /wheels
 
 EXPOSE 8000

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -29,6 +29,9 @@ services:
       TRANSACTION_PAGE_LENGTH: 25
       PRESELECTED_CONTRA_ACCOUNT:
 
+      SESSION_TYPE: redis
+      REDIS_HOST: cache
+
     ports:
       - "8000:8000"
 

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -9,6 +9,10 @@ services:
       POSTGRES_PASSWORD: 'example'
     volumes:
       - db-data:/var/lib/postgresql/data
+
+  cache:
+    image: redis:7.2.4-alpine
+
   app:
     image: ghcr.io/joshuabach/gnucash-web:main
     environment:

--- a/src/encrypted_session/__init__.py
+++ b/src/encrypted_session/__init__.py
@@ -1,1 +1,0 @@
-../EncryptedSession/encrypted_session.py

--- a/src/gnucash_web/__init__.py
+++ b/src/gnucash_web/__init__.py
@@ -10,7 +10,7 @@ from . import auth, book, commodities
 from .utils import jinja as jinja_utils
 from .config import GnuCashWebConfig
 
-from encrypted_session import EncryptedSessionInterface
+from flask_session import Session
 
 
 def create_app(test_config=None):
@@ -30,7 +30,7 @@ def create_app(test_config=None):
 
     # We encrypt the session-cookie, so the DB-password is not stored in plaintext
     # when using AUTH_MECHANISM == 'passthrough'.
-    app.session_interface = EncryptedSessionInterface()
+    Session(app)
 
     if test_config is None:
         # load the instance config, if it exists, when not testing

--- a/src/gnucash_web/config/__init__.py
+++ b/src/gnucash_web/config/__init__.py
@@ -5,9 +5,13 @@ from flask import Config
 
 from . import default
 
+USER_CONFIG_HOME = os.environ.get(
+    'XDG_CONFIG_HOME',
+    os.path.join(os.environ['HOME'], '.config')
+)
 CONFIG_FILES = [
     "/etc/gnucash-web/config.py",
-    f'{os.environ["HOME"]}/.config/gnucash-web/config.py',
+    os.path.join(USER_CONFIG_HOME, 'gnucash-web/config.py'),
 ]
 CONFIG_ENVVAR = "GNUCASH_WEB_CONFIG"
 

--- a/src/gnucash_web/config/default.py
+++ b/src/gnucash_web/config/default.py
@@ -14,3 +14,12 @@ AUTH_MECHANISM = os.getenv('AUTH_MECHANISM')
 
 TRANSACTION_PAGE_LENGTH = int(os.getenv('TRANSACTION_PAGE_LENGTH', 25))
 PRESELECTED_CONTRA_ACCOUNT = os.getenv('PRESELECTED_CONTRA_ACCOUNT')
+
+SESSION_TYPE = os.getenv('SESSION_TYPE', 'redis')
+if SESSION_TYPE == 'redis':
+    import redis
+    SESSION_REDIS = redis.Redis(
+        host=os.getenv('REDIS_HOST', 'localhost'),
+        port=int(os.getenv('REDIS_PORT', 6379)),
+        password=os.getenv('REDIS_PASSWORD'),
+    )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.9.1
 Flask==2.2.5
+Flask-Session==0.8.0
 mysql==0.0.3
 mysqlclient==2.2.0
 piecash==1.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,6 +6,7 @@ mysqlclient==2.2.0
 piecash==1.2.0
 psycopg2==2.9.9
 pycryptodome==3.18.0
+redis==5.0.4
 requests==2.27.1
 Werkzeug==2.3.7
 pytest==7.4.3

--- a/src/setup.py
+++ b/src/setup.py
@@ -63,6 +63,7 @@ setup(
         'pycryptodome>=3.12.0',
         'babel>=2.9.1',
         'requests>=2.27.1',
+        'Flask-Session>=0.8.0'
     ],
     extras_require={
         'pgsql': 'psycopg2',

--- a/src/setup.py
+++ b/src/setup.py
@@ -68,6 +68,7 @@ setup(
     extras_require={
         'pgsql': 'psycopg2',
         'mysql': 'mysql',
+        'redis': 'redis'
     },
 
     entry_points={


### PR DESCRIPTION
Addresses #35 by replacing EncryptedSession with Flask-Session, which stores the session information server side in a configurable store. I've only implemented support in the Docker image for Redis, but manually editing the config.py should allow for any session store which Flask-Session supports ([docs](https://flask-session.readthedocs.io/en/latest/config.html#flask-session-configuration-values)), so long as the required Python modules are also installed.