### PR TITLE
Add Edit Account Functionality

### DIFF
--- a/src/gnucash_web/book.py
+++ b/src/gnucash_web/book.py
@@ -278,12 +278,12 @@ def del_transaction():
 
         return redirect(account_url(account))
 
-@bp.route("/edit_account", methods=["POST"])
+@bp.route("/accounts/<guid>", methods=["POST"])
 @requires_auth
-def edit_account():
+def edit_account(guid):
     """Edit an existing account.
 
-    All parameters are read from `request.form`.
+    All parameters are read from `request.form` except for guid.
 
     :param guid: GUID of the account to edit
     :param name: New name for the account
@@ -297,7 +297,6 @@ def edit_account():
     :param hidden: The hidden state of the account
     """
     try:
-        guid = request.form["guid"]
         name = request.form["name"]
         code = request.form["code"]
         description = request.form["description"]

--- a/src/gnucash_web/templates/account.j2
+++ b/src/gnucash_web/templates/account.j2
@@ -133,8 +133,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
-            <form id="edit_account" method="post" action="{{ url_for('book.edit_account') }}">
-              <input type="hidden" name="guid" value="{{ account.guid }}">
+            <form id="edit_account" method="post" action="{{ url_for('book.edit_account', guid=account.guid) }}">
               <div class="mb-2">
                 <label for="new_account_name" class="form-label text-body-secondary small">Account Name</label>
                 <input type="text" class="form-control"
@@ -164,26 +163,9 @@
                           selected
                         {% endif %}
                       >
-                        {{ p_account.fullname }}
+                        {{ account_type }}
                       </option>
-                      {% if p_account.children %}
-                        {{ loop(p_account.children) }}
-                      {% endif %}
                     {% endif %}
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="mb-2">
-                <label for="new_account_type" class="form-label text-body-secondary small">Account Type</label>
-                <select name="type" id="new_account_type" class="form-select">
-                  {% for account_type in account_types %}
-                    <option value="{{ account_type }}"
-                      {% if account_type == account.type %}
-                        selected
-                      {% endif %}
-                    >
-                      {{ account_type }}
-                    </option>
                   {% endfor %}
                 </select>
               </div>

--- a/src/gnucash_web/templates/account.j2
+++ b/src/gnucash_web/templates/account.j2
@@ -24,12 +24,18 @@
 
 {% block content %}
   {% if account.parent %}
-    <div id="total" class="my-3 list-group">
-      <div class="list-group-item">
-        <b>Total</b>
-        <span class="float-end">
-          {{ account.get_balance() | money(account.commodity) }}
-        </span>
+    <div class="container">
+      <div class="row">
+        <div class="me-2 border rounded p-2 col">
+          <b>Total</b>
+          <span class="float-end">
+            {{ account.get_balance() | money(account.commodity) }}
+          </span>
+        </div>
+        <button type="button" class="btn btn-outline-primary bi bi-pencil-fill col-auto"
+                data-bs-toggle="modal" data-bs-target="#account-edit"
+                title="Edit Account"
+        ></button>
       </div>
     </div>
   {% endif %}
@@ -118,6 +124,133 @@
 {% endblock content %}
 
 {% block modals %}
+  {% if account.parent %}
+    <div class="modal fade" id="account-edit">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Edit Account</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <form id="edit_account" method="post" action="{{ url_for('book.edit_account') }}">
+              <input type="hidden" name="guid" value="{{ account.guid }}">
+              <div class="mb-2">
+                <label for="new_account_name" class="form-label text-body-secondary small">Account Name</label>
+                <input type="text" class="form-control"
+                       name="name" id="new_account_name"
+                       value="{{ account.name }}">
+              </div>
+              <div class="mb-2">
+                <label for="new_account_name" class="form-label text-body-secondary small">Account Code</label>
+                <input type="text" class="form-control"
+                       name="code" id="new_account_code"
+                       value="{{ account.code }}">
+              </div>
+              <div class="mb-2">
+                <label for="new_account_name" class="form-label text-body-secondary small">Description</label>
+                <input type="text" class="form-control"
+                       name="description" id="new_account_desc"
+                       value="{{ account.description }}">
+              </div>
+              <div class="mb-2">
+                <label for="new_account_parent" class="form-label text-body-secondary small">Parent Account</label>
+                <select name="parent" id="new_account_parent" class="form-select">
+                  <option value="{{ book.root_account.guid }}">New top level account</option>
+                  {% for p_account in book.root_account.children | sort(attribute='name') recursive %}
+                    {% if p_account.guid != account.guid %}
+                      <option value="{{ p_account.guid }}"
+                        {% if p_account.guid == account.parent.guid %}
+                          selected
+                        {% endif %}
+                      >
+                        {{ p_account.fullname }}
+                      </option>
+                      {% if p_account.children %}
+                        {{ loop(p_account.children) }}
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="mb-2">
+                <label for="new_account_type" class="form-label text-body-secondary small">Account Type</label>
+                <select name="type" id="new_account_type" class="form-select">
+                  {% for account_type in account_types %}
+                    <option value="{{ account_type }}"
+                      {% if account_type == account.type %}
+                        selected
+                      {% endif %}
+                    >
+                      {{ account_type }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="mb-2">
+                <label for="new_account_commodity" class="form-label text-body-secondary small">Commodity</label>
+                <select name="commodity" id="new_account_commodity" class="form-select">
+                  {% for commodity in book.commodities %}
+                    <option value="{{ commodity.mnemonic }}"
+                      {% if account.commodity == commodity %}
+                        selected
+                      {% endif %}
+                    >
+                      {{ commodity.mnemonic }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+
+              <div class="mb-2">
+                <label for="new_account_commodity_scu" class="form-label text-body-secondary small">Smallest Fraction</label>
+                <select name="commodity_scu" id="new_account_commodity_scu" class="form-select">
+                  <option value="-1"
+                    {% if account.non_std_scu == 0 %}
+                      selected
+                    {% endif %}
+                  >
+                    Use Commodity Value
+                  </option>
+                  {% for n in range(10) %}
+                    <option value="{{ 10 ** n }}"
+                      {% if account.non_std_scu == 1 and account.commodity_scu == 10 ** n %}
+                        selected
+                      {% endif %}
+                    >
+                      1/{{10 ** n}}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="placeholder" id="new_account_placeholder"
+                  {% if account.placeholder == 1 %}
+                    checked
+                  {% endif %}
+                >
+                <label class="form-check-label" for="new_account_placeholder">Placeholder</label>
+              </div>
+
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="hidden" id="new_account_hidden"
+                  {% if account.hidden == 1 %}
+                    checked
+                  {% endif %}
+                >
+                <label class="form-check-label" for="new_account_hidden">Hidden</label>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-primary" form="edit_account" type="submit">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   {% if not account.placeholder and account.parent %}
     <div class="modal fade" id="edit-transaction">
       <div class="modal-dialog">


### PR DESCRIPTION
Adds a modal form in the Accounts template to edit details about an account along with a new route, '/edit_account' to handle the submission. Is not 100% feature complete with the desktop application. Notably the account type can be set regardless of parent account type, which causes an error when attempting to save. Doing so would require a more reactive front end which is a potential future improvement.

I don't use commodities, so I'm not sure if the commodities selector is working as expected or not.

Could be a fix for #17.