### PR TITLE
Handle exceptions when retrieving account balances

### DIFF
--- a/src/gnucash_web/__init__.py
+++ b/src/gnucash_web/__init__.py
@@ -54,6 +54,7 @@ def create_app(test_config=None):
     app.jinja_env.filters['full_account_names'] = jinja_utils.full_account_names
     app.jinja_env.filters['contrasplits'] = jinja_utils.contra_splits
     app.jinja_env.filters['nth'] = jinja_utils.nth
+    app.jinja_env.filters['safe_get_balance'] = jinja_utils.safe_get_balance
     app.jinja_env.globals['is_authenticated'] = auth.is_authenticated
 
     with (Path(__file__).parent / 'version.txt').open() as version:

--- a/src/gnucash_web/templates/account.j2
+++ b/src/gnucash_web/templates/account.j2
@@ -28,7 +28,7 @@
       <div class="list-group-item">
         <b>Total</b>
         <span class="float-end">
-          {{ account.get_balance() | money(account.commodity) }}
+          {{ account | safe_get_balance | money(account.commodity) }}
         </span>
       </div>
     </div>
@@ -54,7 +54,7 @@
           </a>
 
           <span class="float-end">
-            {{ account.get_balance() | money(account.commodity) }}
+            {{ account | safe_get_balance | money(account.commodity) }}
           </span>
         </div>
 


### PR DESCRIPTION
This PR adds a `safe_get_balance` Jinja filter to handle exceptions raised by `Account.get_balance()`. When an exception occurs, the balance field now shows "Error" instead of causing an HTTP 500 error.
